### PR TITLE
コンソールに出る無限ループエラーの修正

### DIFF
--- a/src/component/pages/Home.tsx
+++ b/src/component/pages/Home.tsx
@@ -53,8 +53,12 @@ const Home = () => {
         return 1; // taskAが未完了、taskBが完了なのでtaskAを後ろに
       }
     });
-    setTaskList(sortedTasks);
-  }, [taskList]);
+
+    // taskListがすでにソートされていない場合のみ更新する
+    if (JSON.stringify(taskList) !== JSON.stringify(sortedTasks)) {
+      setTaskList(sortedTasks);
+    }
+  }, []); 
 
   return (
     <>

--- a/src/component/pages/Home.tsx
+++ b/src/component/pages/Home.tsx
@@ -58,7 +58,7 @@ const Home = () => {
     if (JSON.stringify(taskList) !== JSON.stringify(sortedTasks)) {
       setTaskList(sortedTasks);
     }
-  }, []); 
+  }, [taskList]); 
 
   return (
     <>

--- a/src/component/pages/Home.tsx
+++ b/src/component/pages/Home.tsx
@@ -4,42 +4,42 @@ import { useEffect, useState } from 'react';
 import { Task } from '../../types/Task';
 import MakeTaskButton from '../templates/MakeTaskButton';
 
-const Home = () => {
-  const initializeTasks = (): Task[] => {
-    const storedOptions = localStorage.getItem('localTaskList');
+const initializeTasks = (): Task[] => {
+  const storedOptions = localStorage.getItem('localTaskList');
 
-    if (storedOptions) {
-      const parsedOptions = JSON.parse(storedOptions);
-      return parsedOptions.map((task: Task) => ({
-        ...task,
-        timeLimit: new Date(task.timeLimit),
-      }));
-    } else {
-      return [
-        {
-          id: 1,
-          title: 'Task 1',
-          isDone: false,
-          timeLimit: new Date('2024-06-23T23:59'),
-          taskDetail: 'Detail of Task 1',
-        },
-        {
-          id: 2,
-          title: 'Task 2',
-          isDone: true,
-          timeLimit: new Date('2024-07-01T23:59'),
-          taskDetail: 'Detail of Task 2',
-        },
-        {
-          id: 3,
-          title: 'Task 3',
-          isDone: false,
-          timeLimit: new Date('2024-07-15T23:59'),
-          taskDetail: 'Detail of Task 3',
-        },
-      ];
-    }
-  };
+  if (storedOptions) {
+    const parsedOptions = JSON.parse(storedOptions);
+    return parsedOptions.map((task: Task) => ({
+      ...task,
+      timeLimit: new Date(task.timeLimit),
+    }));
+  } else {
+    return [
+      {
+        id: 1,
+        title: 'Task 1',
+        isDone: false,
+        timeLimit: new Date('2024-06-23T23:59'),
+        taskDetail: 'Detail of Task 1',
+      },
+      {
+        id: 2,
+        title: 'Task 2',
+        isDone: true,
+        timeLimit: new Date('2024-07-01T23:59'),
+        taskDetail: 'Detail of Task 2',
+      },
+      {
+        id: 3,
+        title: 'Task 3',
+        isDone: false,
+        timeLimit: new Date('2024-07-15T23:59'),
+        taskDetail: 'Detail of Task 3',
+      },
+    ];
+  }
+};
+const Home = () => {
 
   const [taskList, setTaskList] = useState<Task[]>(initializeTasks);
 

--- a/src/component/pages/Home.tsx
+++ b/src/component/pages/Home.tsx
@@ -43,15 +43,14 @@ const Home = () => {
 
   const [taskList, setTaskList] = useState<Task[]>(initializeTasks);
 
-  useEffect(() => {
-    const sortedTasks = [...taskList].sort((taskA, taskB) => {
-      if (taskA.isDone === taskB.isDone) {
-        return 0;
-      } else if (taskA.isDone) {
-        return -1; // taskAが完了、taskBが未完了なのでtaskAを前に
-      } else {
-        return 1; // taskAが未完了、taskBが完了なのでtaskAを後ろに
-      }
+  useEffect(() =>
+  {
+    const sortedTasks = [...taskList].sort((taskA, taskB) =>
+    {
+      //0は何もしない、1はtaskAを前に、-1はtaskBを前に
+      return taskA.isDone === taskB.isDone
+        ? 0
+        : taskA.isDone ? -1 : 1;
     });
 
     // taskListがすでにソートされていない場合のみ更新する

--- a/src/component/pages/Home.tsx
+++ b/src/component/pages/Home.tsx
@@ -10,7 +10,7 @@ const Home = () => {
 
     if (storedOptions) {
       const parsedOptions = JSON.parse(storedOptions);
-      return parsedOptions.map((task: any) => ({
+      return parsedOptions.map((task: Task) => ({
         ...task,
         timeLimit: new Date(task.timeLimit),
       }));


### PR DESCRIPTION
コンソールに表示されるエラーの修正
エラー内容:useEffect フック内で setState が呼び出され、その結果レンダリングが無限ループに入ってしまう
対策:taskListがすでにソートされていない場合のみ更新する。依存関係をなくす

